### PR TITLE
Statistics enhancements

### DIFF
--- a/contracts/contracts/metrics/Statistics.sol
+++ b/contracts/contracts/metrics/Statistics.sol
@@ -78,7 +78,6 @@ contract Statistics is Initializable {
                 ? playerStats[player][level].timeSubmitted
                 : new uint256[](0)
         );
-
         levelStats[level].noOfInstancesCreated++;
         globalNoOfInstancesCreated++;
         globalNoOfInstancesCreatedByPlayer[player]++;
@@ -93,21 +92,17 @@ contract Statistics is Initializable {
             playerStats[player][level].instance != address(0),
             "Instance for the level is not created"
         );
-
         require(
             playerStats[player][level].instance == instance,
             "Submitted instance is not the created one"
         );
-
         require(
             playerStats[player][level].isCompleted == false,
             "Level already completed"
         );
-
         if(firstSubmissionTime[player][level] == 0) {
             firstSubmissionTime[player][level] = block.timestamp;
         }
-
         playerStats[player][level].timeSubmitted.push(block.timestamp);
         playerStats[player][level].timeCompleted = block.timestamp;
         playerStats[player][level].isCompleted = true;

--- a/contracts/contracts/metrics/Statistics.sol
+++ b/contracts/contracts/metrics/Statistics.sol
@@ -7,7 +7,7 @@ contract Statistics is Initializable {
     address[] public players;
     address[] public levels;
     uint256 private globalNoOfInstancesCreated;
-    uint256 private globalNoOfInstancesSolved;
+    uint256 private globalNoOfInstancesCompleted;
     uint256 private globalNoOfInstancesFailures;
     struct LevelInstance {
         address instance;
@@ -21,9 +21,9 @@ contract Statistics is Initializable {
         uint256 noOfInstancesSubmitted_Success;
         uint256 noOfInstancesSubmitted_Fail;
     }
-    mapping(address => uint256) private globalNoOfLevelsCreatedByPlayer;
+    mapping(address => uint256) private globalNoOfLevelsCompletedByPlayer;
     mapping(address => uint256) private globalNoOfInstancesCreatedByPlayer;
-    mapping(address => uint256) private globalNoOfInstancesSolvedByPlayer;
+    mapping(address => uint256) private globalNoOfInstancesCompletedByPlayer;
     mapping(address => uint256) private globalNoOfInstancesFailuresByPlayer;
     mapping(address => Level) private levelStats;
     mapping(address => mapping(address => uint256)) private firstInstanceCreationTime;
@@ -65,8 +65,8 @@ contract Statistics is Initializable {
             players.push(player);
             playerExists[player] = true;
         }
+        // If it is the first instance of the level
         if(playerStats[player][level].instance == address(0)) {
-            globalNoOfLevelsCreatedByPlayer[player]++;
             firstInstanceCreationTime[player][level] = block.timestamp;
         }
         playerStats[player][level] = LevelInstance(
@@ -100,15 +100,17 @@ contract Statistics is Initializable {
             playerStats[player][level].isCompleted == false,
             "Level already completed"
         );
+        // If it is the first submission in the level
         if(firstSubmissionTime[player][level] == 0) {
+            globalNoOfLevelsCompletedByPlayer[player]++;
             firstSubmissionTime[player][level] = block.timestamp;
         }
         playerStats[player][level].timeSubmitted.push(block.timestamp);
         playerStats[player][level].timeCompleted = block.timestamp;
         playerStats[player][level].isCompleted = true;
         levelStats[level].noOfInstancesSubmitted_Success++;
-        globalNoOfInstancesSolved++;
-        globalNoOfInstancesSolvedByPlayer[player]++;
+        globalNoOfInstancesCompleted++;
+        globalNoOfInstancesCompletedByPlayer[player]++;
     }
 
     function submitFailure(
@@ -145,7 +147,7 @@ contract Statistics is Initializable {
 
     // Player specific metrics
     // number of levels created by player
-    function getTotalNoOfLevelsCreatedByPlayer(address player)
+    function getTotalNoOfLevelInstancesCreatedByPlayer(address player)
         public
         view
         playerExistsCheck(player)
@@ -155,23 +157,32 @@ contract Statistics is Initializable {
     }
 
     // number of levels completed by player
-    function getTotalNoOfLevelsCompletedByPlayer(address player)
+    function getTotalNoOfLevelInstancesCompletedByPlayer(address player)
         public
         view
         playerExistsCheck(player)
         returns (uint256)
     {
-        return globalNoOfInstancesSolvedByPlayer[player];
+        return globalNoOfInstancesCompletedByPlayer[player];
     }
 
     // number of levels failed by player
-    function getTotalNoOfLevelsFailedByPlayer(address player)
+    function getTotalNoOfLevelInstancesFailedByPlayer(address player)
         public
         view
         playerExistsCheck(player)
         returns (uint256)
     {
         return globalNoOfInstancesFailuresByPlayer[player];
+    }
+
+    function getTotalNoOfLevelsCompletedByPlayer(address player)
+        public
+        view
+        playerExistsCheck(player)
+        returns (uint256)
+    {
+        return globalNoOfLevelsCompletedByPlayer[player];
     }
 
     // number of failed submissions of a specific level by player (0 if player didn't play the level)
@@ -191,7 +202,7 @@ contract Statistics is Initializable {
                 : 0;
     }
 
-    // Is a specific level solved by a specific player ?
+    // Is a specific level completed by a specific player ?
     function isLevelCompleted(address player, address level)
         public
         view
@@ -202,7 +213,7 @@ contract Statistics is Initializable {
         return playerStats[player][level].isCompleted;
     }
 
-    // How much time a player took to solve a level (in seconds)
+    // How much time a player took to complete a level (in seconds)
     function getTimeElapsedForCompletionOfLevel(address player, address level)
         public
         view
@@ -249,15 +260,15 @@ contract Statistics is Initializable {
     }
 
     // Game specific metrics
-    function getTotalNoOfLevelsCreated() public view returns (uint256) {
+    function getTotalNoOfLevelInstancesCreated() public view returns (uint256) {
         return globalNoOfInstancesCreated;
     }
 
-    function getTotalNoOfLevelsCompleted() public view returns (uint256) {
-        return globalNoOfInstancesSolved;
+    function getTotalNoOfLevelInstancesCompleted() public view returns (uint256) {
+        return globalNoOfInstancesCompleted;
     }
 
-    function getTotalNoOfLevelsFailures() public view returns (uint256) {
+    function getTotalNoOfLevelInstancesFailures() public view returns (uint256) {
         return globalNoOfInstancesFailures;
     }
 

--- a/contracts/contracts/metrics/Statistics.sol
+++ b/contracts/contracts/metrics/Statistics.sol
@@ -8,7 +8,7 @@ contract Statistics is Initializable {
     address[] public levels;
     uint256 private globalNoOfInstancesCreated;
     uint256 private globalNoOfInstancesCompleted;
-    uint256 private globalNoOfInstancesFailures;
+    uint256 private globalNoOfFailedSubmissions;
     struct LevelInstance {
         address instance;
         bool isCompleted;
@@ -19,12 +19,12 @@ contract Statistics is Initializable {
     struct Level {
         uint256 noOfInstancesCreated;
         uint256 noOfInstancesSubmitted_Success;
-        uint256 noOfInstancesSubmitted_Fail;
+        uint256 noOfSubmissions_Failed;
     }
     mapping(address => uint256) private globalNoOfLevelsCompletedByPlayer;
     mapping(address => uint256) private globalNoOfInstancesCreatedByPlayer;
     mapping(address => uint256) private globalNoOfInstancesCompletedByPlayer;
-    mapping(address => uint256) private globalNoOfInstancesFailuresByPlayer;
+    mapping(address => uint256) private globalNoOfFailedSubmissionsByPlayer;
     mapping(address => Level) private levelStats;
     mapping(address => mapping(address => uint256)) private firstInstanceCreationTime;
     mapping(address => mapping(address => uint256)) private firstSubmissionTime;
@@ -131,9 +131,9 @@ contract Statistics is Initializable {
             "Level already completed"
         );
         playerStats[player][level].timeSubmitted.push(block.timestamp);
-        levelStats[level].noOfInstancesSubmitted_Fail++;
-        globalNoOfInstancesFailures++;
-        globalNoOfInstancesFailuresByPlayer[player]++;
+        levelStats[level].noOfSubmissions_Failed++;
+        globalNoOfFailedSubmissions++;
+        globalNoOfFailedSubmissionsByPlayer[player]++;
     }
 
     function saveNewLevel(address level)
@@ -167,13 +167,13 @@ contract Statistics is Initializable {
     }
 
     // number of levels failed by player
-    function getTotalNoOfLevelInstancesFailedByPlayer(address player)
+    function getTotalNoOfFailedSubmissionsByPlayer(address player)
         public
         view
         playerExistsCheck(player)
         returns (uint256)
     {
-        return globalNoOfInstancesFailuresByPlayer[player];
+        return globalNoOfFailedSubmissionsByPlayer[player];
     }
 
     function getTotalNoOfLevelsCompletedByPlayer(address player)
@@ -268,21 +268,21 @@ contract Statistics is Initializable {
         return globalNoOfInstancesCompleted;
     }
 
-    function getTotalNoOfLevelInstancesFailures() public view returns (uint256) {
-        return globalNoOfInstancesFailures;
+    function getTotalNoOfFailedSubmissions() public view returns (uint256) {
+        return globalNoOfFailedSubmissions;
     }
 
     function getTotalNoOfPlayers() public view returns (uint256) {
         return players.length;
     }
 
-    function getNoOfFailedSubmissionForLevel(address level)
+    function getNoOfFailedSubmissionsForLevel(address level)
         public
         view
         levelExistsCheck(level)
         returns (uint256)
     {
-        return levelStats[level].noOfInstancesSubmitted_Fail;
+        return levelStats[level].noOfSubmissions_Failed;
     }
 
     function getNoOfInstancesForLevel(address level)
@@ -294,7 +294,7 @@ contract Statistics is Initializable {
         return levelStats[level].noOfInstancesCreated;
     }
 
-    function getNoOfCompletedSubmissionForLevel(address level)
+    function getNoOfCompletedSubmissionsForLevel(address level)
         public
         view
         levelExistsCheck(level)

--- a/contracts/test/metrics/level.test.js
+++ b/contracts/test/metrics/level.test.js
@@ -68,7 +68,7 @@ contract('Level metrics', (accounts) => {
             })
 
             it('checks no of failed submissions', async () => { 
-                expect((await statistics.getTotalNoOfLevelInstancesFailures()).toNumber()).to.equal(2)
+                expect((await statistics.getTotalNoOfFailedSubmissions()).toNumber()).to.equal(2)
             })
         })
 
@@ -80,13 +80,13 @@ contract('Level metrics', (accounts) => {
             })
 
             it('checks the no of completed instances of a level', async () => {
-                expect((await statistics.getNoOfCompletedSubmissionForLevel(LEVEL_FACTORY_ADDRESS_1)).toNumber()).to.equal(2)
-                expect((await statistics.getNoOfCompletedSubmissionForLevel(LEVEL_FACTORY_ADDRESS_2)).toNumber()).to.equal(1)
+                expect((await statistics.getNoOfCompletedSubmissionsForLevel(LEVEL_FACTORY_ADDRESS_1)).toNumber()).to.equal(2)
+                expect((await statistics.getNoOfCompletedSubmissionsForLevel(LEVEL_FACTORY_ADDRESS_2)).toNumber()).to.equal(1)
             })
 
             it('checks the no of failed instances of a level', async () => {
-                expect((await statistics.getNoOfFailedSubmissionForLevel(LEVEL_FACTORY_ADDRESS_2)).toNumber()).to.equal(1)
-                expect((await statistics.getNoOfFailedSubmissionForLevel(LEVEL_FACTORY_ADDRESS_3)).toNumber()).to.equal(1)
+                expect((await statistics.getNoOfFailedSubmissionsForLevel(LEVEL_FACTORY_ADDRESS_2)).toNumber()).to.equal(1)
+                expect((await statistics.getNoOfFailedSubmissionsForLevel(LEVEL_FACTORY_ADDRESS_3)).toNumber()).to.equal(1)
             })
         })
     });

--- a/contracts/test/metrics/level.test.js
+++ b/contracts/test/metrics/level.test.js
@@ -46,7 +46,7 @@ contract('Level metrics', (accounts) => {
             })
 
             it('checks no of level instances created', async () => {
-                expect((await statistics.getTotalNoOfLevelsCreated()).toNumber()).to.equal(5)
+                expect((await statistics.getTotalNoOfLevelInstancesCreated()).toNumber()).to.equal(5)
             })
 
             it('checks total no of players', async () => { 
@@ -64,11 +64,11 @@ contract('Level metrics', (accounts) => {
             })
 
             it('checks no of completed submissions', async () => {
-                expect((await statistics.getTotalNoOfLevelsCompleted()).toNumber()).to.equal(3)
+                expect((await statistics.getTotalNoOfLevelInstancesCompleted()).toNumber()).to.equal(3)
             })
 
             it('checks no of failed submissions', async () => { 
-                expect((await statistics.getTotalNoOfLevelsFailures()).toNumber()).to.equal(2)
+                expect((await statistics.getTotalNoOfLevelInstancesFailures()).toNumber()).to.equal(2)
             })
         })
 

--- a/contracts/test/metrics/player.test.js
+++ b/contracts/test/metrics/player.test.js
@@ -107,7 +107,7 @@ contract('Player metrics', (accounts) => {
       })
 
       it('should return total number of levels failed', async () => {
-        const totalLevels = await statistics.getTotalNoOfLevelInstancesFailedByPlayer(PLAYER_ADDRESS_1);
+        const totalLevels = await statistics.getTotalNoOfFailedSubmissionsByPlayer(PLAYER_ADDRESS_1);
         await expect(totalLevels.toNumber()).to.equal(2);
       })
 

--- a/contracts/test/metrics/player.test.js
+++ b/contracts/test/metrics/player.test.js
@@ -13,10 +13,12 @@ contract('Player metrics', (accounts) => {
     ETHERNAUT_ADDRESS,
     PLAYER_ADDRESS_1,
     PLAYER_ADDRESS_2,
+    PLAYER_ADDRESS_3,
     LEVEL_FACTORY_ADDRESS_1,
     LEVEL_FACTORY_ADDRESS_2,
     LEVEL_INSTANCE_ADDRESS_1,
-    LEVEL_INSTANCE_ADDRESS_2
+    LEVEL_INSTANCE_ADDRESS_2,
+    LEVEL_INSTANCE_ADDRESS_3
   ] = accounts;
 
   describe('Statistics', function () {
@@ -115,5 +117,15 @@ contract('Player metrics', (accounts) => {
       })
     })
   });
+
+  describe("Calculation of time taken for completion of a level", async () => { 
+    it('should calculate time taken for completion of a level', async () => { 
+      await statistics.createNewInstance(LEVEL_INSTANCE_ADDRESS_1, LEVEL_FACTORY_ADDRESS_1, PLAYER_ADDRESS_3);
+      await statistics.createNewInstance(LEVEL_INSTANCE_ADDRESS_2, LEVEL_FACTORY_ADDRESS_1, PLAYER_ADDRESS_3);
+      await statistics.createNewInstance(LEVEL_INSTANCE_ADDRESS_3, LEVEL_FACTORY_ADDRESS_1, PLAYER_ADDRESS_3);
+      await statistics.submitSuccess(LEVEL_INSTANCE_ADDRESS_3, LEVEL_FACTORY_ADDRESS_1, PLAYER_ADDRESS_3);
+      expect((await statistics.getTimeElapsedForCompletionOfLevel(PLAYER_ADDRESS_3, LEVEL_FACTORY_ADDRESS_1)).toNumber()).to.equal(3);
+    })
+  })
 });
 

--- a/contracts/test/metrics/player.test.js
+++ b/contracts/test/metrics/player.test.js
@@ -97,17 +97,17 @@ contract('Player metrics', (accounts) => {
 
     describe("Total number of levels created", async () => {
       it('should return total number of levels created', async () => {
-        const totalLevels = await statistics.getTotalNoOfLevelsCreatedByPlayer(PLAYER_ADDRESS_1);
+        const totalLevels = await statistics.getTotalNoOfLevelInstancesCreatedByPlayer(PLAYER_ADDRESS_1);
         await expect(totalLevels.toNumber()).to.equal(2);
       })
 
       it('should return total number of levels completed', async () => {
-        const totalLevels = await statistics.getTotalNoOfLevelsCompletedByPlayer(PLAYER_ADDRESS_1);
+        const totalLevels = await statistics.getTotalNoOfLevelInstancesCompletedByPlayer(PLAYER_ADDRESS_1);
         await expect(totalLevels.toNumber()).to.equal(1);
       })
 
       it('should return total number of levels failed', async () => {
-        const totalLevels = await statistics.getTotalNoOfLevelsFailedByPlayer(PLAYER_ADDRESS_1);
+        const totalLevels = await statistics.getTotalNoOfLevelInstancesFailedByPlayer(PLAYER_ADDRESS_1);
         await expect(totalLevels.toNumber()).to.equal(2);
       })
 


### PR DESCRIPTION
1. Added globalNoOfLevelsCompletedByPlayer and used that in the percentage calculation
2. Added firstInstanceCreationTime and firstSubmissionTime and used that in the calculation of time taken for completion of a level
3. Added test case for the above calculation
4. We were using solve and complete terminology in different places, changed it to complete to have consistent naming
5. We were using number and no for number. Changed that to no in all places
6. Also in the getters, I made explicit whether we are getting levels or level instances as now we have globalNoOfLevelsCompletedByPlayer which refers to levels not instances
7. Also I have made a variable name change here https://github.com/CeliktepeMurat/ethernaut/pull/6/commits/718e26d42b0f1de7cb3a13e332361a2e4b29bf2b This is done because we can have multiple failed submissions for a single level instance. If this makes sense, we can keep it, otherwise we can revert.